### PR TITLE
Adds native Backbone event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Backbone-kinship
 
-A simple, lightweight, Backbone model adding 1-1 and 1-N relations. No shared instances, data pooling or reversed relations. It's really just a way to expand nested data into models and collections.
+A simple, lightweight, Backbone model adding 1-1 and 1-N relations. No shared instances, data pooling or reversed relations. It's really just an easy way to expand nested data into models and collections.
 
 ## Creating a model with relations
 
@@ -51,7 +51,7 @@ console.log(myRelationalModelInstance.myOtherRelation.get("name"));
 
 ## Events
 
-Events are propagated from their relationships as `eventName:relationshipName`. The following events also triggers a change event: "add", "remove", "change", "reset". Like so:
+Events are propagated from their relationships as `eventName:relationshipName`, like so:
 ``` javascript
 myRelationalModelInstance.on("all", function(e) {
   console.log(e);
@@ -62,8 +62,9 @@ myRelationalModelInstance.get("myFirstRelation").add({
   eatenBy: "panda"
 });
 
->> "change"
 >> "add:myFirstRelation"
+>> "change:myFirstRelation"
+>> "change"
 ```
 ----
 Backbone-kinship is released under the MIT license.

--- a/backbone-kinship.js
+++ b/backbone-kinship.js
@@ -7,7 +7,7 @@
 * }
 * After that the related collection/model instances are available both directly on the
 * model (Model.my-first-relation) and by using Model.get (Model.get("my-first-relation")).
-* Note that relations are undefined until they have been assigned a value.
+* Note that model relations are undefined until they have been assigned a value.
 */
 (function(root, factory) {
   "use strict";
@@ -23,16 +23,16 @@
 	else {
 		factory(root, root.Backbone, root._);
 	}
-} (this, function(exports, Backbone, _) {
+} (this, function (exports, Backbone, _) {
   Backbone.RelationalModel = Backbone.Model.extend({
     relations: {},
 
-    get: function(key) {
+    get: function (key) {
       return this.relations[key] ? this[key] : Backbone.Model.prototype.get.call(this, key);
     },
 
-    set: function(key, value, options) {
-      var attributes, isCloned;
+    set: function (key, value, options) {
+      var returnValue;
       // Handling the two function signatures, either key-value or attribute object
       if (_.isObject(key)) {
         attributes = key;
@@ -40,116 +40,75 @@
       } else {
         (attributes = {})[key] = value;
       }
-      // Initializing relational functionality (if it's not already done)
-      if (!this._attributes) {
-        // Setting up internal getter and setter for attributes to keep it clean
-        // from the actual releated models and collections
-        this._attributes = _.clone(this.attributes);
-        Object.defineProperty(this, "attributes", {
-          configurable: true,
-          enumerable: true,
-          get: function() {
-            return getAttributes(this);
-          },
-          set: function(value) {
-            return setAttributes(this, value);
-          }
-        });
-      }
       // Checking if any relations are among the attributes
-      _.each(this.relations, function(constructor, name) {
-        var entity;
-        var setMethod = "set";
-        // Making sure that this relation is set up
+      _.each(this.relations, function (constructor, name) {
+        var object;
+        // Setting up relational functionality for this attribute (if it's not already done)
         if (!this[name]) {
-          // Setting up new relation
-          entity = new constructor();
+          object = new constructor();
           // Only collections can be set up without data
-          if (typeof attributes[name] !== "undefined" || entity instanceof Backbone.Collection) {
-            this[name] = entity;
-            // Setting up dispatcher for relational events, for example that "add" on a relation called "collection" would trigger the event "collection:add" on this model
-            delegateEvents(this[name], this, name);
-          }
-          // Initial sets are always resets (if possible and unless required otherwise)
-          if ((!options || typeof options.reset === "undefined") && entity.reset) {
-            setMethod = "reset";
+          if (typeof attributes[name] !== "undefined" || object instanceof Backbone.Collection) {
+            this[name] = object;
+            // Setting up getter and setter for this attribute (so that it can be expanded)
+            defineRelatedAttribute(this, name, object);
+            // Setting up dispatcher for relational events
+            delegateEvents(object, this, name);
           }
         }
-        // Checking if there is data for this relation
-        if (typeof attributes[name] !== "undefined") {
-          // Switching to reset if required (and possible)
-          if (options && options.reset && this[name].reset) {
-            setMethod = "reset";
-          }
-          // Handling both key-value and attribute signatures
-          if (_.isObject(attributes[name])) {
-            this[name][setMethod](attributes[name], options);
-          } else {
-            this[name][setMethod](attributes[name], attributes[name].value, options);
-          }
-          // Removing relational data so it isn't also set on the model
-          if (key[name]) {
-             // Cloning to avoid affecting other users of this object (but we don't want to clone it more than once because performace)
-            if (!isCloned) {
-              key = _.clone(key);
-              isCloned = true;
-            }
-            delete key[name]; // Deleting from attribute object
-          } else {
-            key = null;
-          }
+        if (name in attributes) {
+          // "Propagating" set options
+          this[name]._setOptions = options;
         }
       }, this);
-      if (key) {
-        Backbone.Model.prototype.set.call(this, key, value, options);
+      // Letting Backbone do its real set magic
+      returnValue = Backbone.Model.prototype.set.call(this, key, value, options);
+      // Unsetting means that all attributes get wiped, including our attribute
+      // relations, so we handle that.
+      if (options && options.unset) {
+        _.each(this.relations, function (constructor, name) {
+          if (name in attributes && this[name]) {
+            if (this[name] instanceof Backbone.Collection) {
+              // Reconnecting unset collections (since an unset collection attribute is just an empty collection)
+              defineRelatedAttribute(this, name, this[name]);
+            } else {
+              // Removing others unset relations
+              delete this[name];
+            }
+          }
+        }, this);
       }
-      return this;
+      return returnValue;
     }
   });
 
   /**
-  * These events should also trigger a "change" event.
+  * Connects a model attribute to a related model or collection
+  * @param model The model to add the connection to
+  * @param name The name of attribute
+  * @param object The backbone object to connect
   */
-  var CHANGE_EVENTS = {
-    add: true,
-    remove: true,
-    change: true,
-    reset: true
-  };
-
-  /**
-  * Returns all attributes for a model
-  * Relational attributes will be JSONified
-  * @param model A Backbone-kinship Model
-  * @return Model attributes
-  */
-  function getAttributes(model) {
-    var attributes = model._attributes;
-    // Adding expanded json data from all relations
-    _.each(model.relations, function(constructor, name) {
-      if (model[name]) {
-        attributes[name] = model[name].toJSON();
+  function defineRelatedAttribute(model, name, object) {
+    Object.defineProperty(model.attributes, name, {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        return object.toJSON();
+      },
+      set: function (value) {
+        var options = object._setOptions;
+        var method = options && options.reset && object.reset ? "reset" : "set";
+        delete object._setOptions;
+        return object[method](value, options);
       }
     });
-    return attributes;
   }
-  
+
   /**
-  * Sets attributes for a model
-  * @param model A Backbone-kinship Model
-  * @param value The value to set
-  */
-  function setAttributes(model, value) {
-    model._attributes = value;
-  }
-  
-  /*
   * Delegates all events from one entity to another, on the format
-  * eventName:fromName. A "change" event will also be triggered for "add", "remove",
-  * "change" and "reset" events.
+  * eventName:fromName.
   * @param from The entity that emits the event
   * @param to The entity that should receive the event
-  * @param fromName Display name to use to show where this event originated
+  * @param fromName Display name to use for showing where this event originated
   */
   function delegateEvents(from, to, fromName) {
     from.bind("all", function() {
@@ -157,10 +116,6 @@
       var eventName = args[0];
       args[0] = eventName + ":" + fromName;
       to.trigger.apply(to, args);
-      if (CHANGE_EVENTS[eventName]) {
-        args[0] = "change";
-        to.trigger.apply(to, args);
-      }
     });
   }
 }));

--- a/backbone-kinship.js
+++ b/backbone-kinship.js
@@ -7,7 +7,7 @@
 * }
 * After that the related collection/model instances are available both directly on the
 * model (Model.my-first-relation) and by using Model.get (Model.get("my-first-relation")).
-* Note that model relations are undefined until they have been assigned a value.
+* Note that relations are undefined until they have been assigned a value.
 */
 (function(root, factory) {
   "use strict";
@@ -23,16 +23,29 @@
 	else {
 		factory(root, root.Backbone, root._);
 	}
-} (this, function (exports, Backbone, _) {
+} (this, function(exports, Backbone, _) {
+
+  // Temporary data per model
+  var settingData = {};
+  
   Backbone.RelationalModel = Backbone.Model.extend({
     relations: {},
-
-    get: function (key) {
+    
+    /**
+    * Overrides standard Backbone functionality
+    */
+    get: function(key) {
       return this.relations[key] ? this[key] : Backbone.Model.prototype.get.call(this, key);
     },
 
-    set: function (key, value, options) {
-      var returnValue;
+    /**
+    * Overrides standard Backbone functionality
+    */
+    set: function(key, value, options) {
+      var changeWasTriggered = false;
+      var attributes, isCloned, delayedEvents;
+      // Initializing setting
+      isSetting(this, true);
       // Handling the two function signatures, either key-value or attribute object
       if (_.isObject(key)) {
         attributes = key;
@@ -40,82 +53,209 @@
       } else {
         (attributes = {})[key] = value;
       }
+      // Initializing relational functionality (if it's not already done)
+      if (!this._attributes) {
+        // Setting up internal getter and setter for attributes to keep it clean
+        // from the actual releated models and collections
+        this._attributes = _.clone(this.attributes);
+        Object.defineProperty(this, "attributes", {
+          configurable: true,
+          enumerable: true,
+          get: function () {
+            return getAttributes(this);
+          },
+          set: function(value) {
+            return setAttributes(this, value);
+          }
+        });
+      }
       // Checking if any relations are among the attributes
-      _.each(this.relations, function (constructor, name) {
-        var object;
-        // Setting up relational functionality for this attribute (if it's not already done)
+      _.each(this.relations, function(constructor, name) {
+        var setMethod = "set";
+        var entity;
+        // Making sure that this relation is set up
         if (!this[name]) {
-          object = new constructor();
+          // Setting up new relation
+          entity = new constructor();
           // Only collections can be set up without data
-          if (typeof attributes[name] !== "undefined" || object instanceof Backbone.Collection) {
-            this[name] = object;
-            // Setting up getter and setter for this attribute (so that it can be expanded)
-            defineRelatedAttribute(this, name, object);
-            // Setting up dispatcher for relational events
-            delegateEvents(object, this, name);
+          if (typeof attributes[name] !== "undefined" || entity instanceof Backbone.Collection) {
+            this[name] = entity;
+            // Setting up dispatcher for relational events, for example that "add" on a relation called "collection" would trigger the event "collection:add" on this model
+            delegateEvents(this[name], this, name);
           }
         }
-        if (name in attributes) {
-          // "Propagating" set options
-          this[name]._setOptions = options;
+        // Checking if there is data for this relation
+        if (typeof attributes[name] !== "undefined") {
+          // Switching to reset if required (and possible)
+          if (options && options.reset && this[name].reset) {
+            setMethod = "reset";
+          }
+          // Handling both key-value and attribute signatures
+          if (_.isObject(attributes[name])) {
+            this[name][setMethod](attributes[name], options);
+          } else {
+            this[name][setMethod](attributes[name], attributes[name].value, options);
+          }
+          // Removing relational data so it isn't also set on the model
+          if (key[name]) {
+             // Cloning to avoid affecting other users of this object (but we don't want to clone it more than once because performace)
+            if (!isCloned) {
+              key = _.clone(key);
+              isCloned = true;
+            }
+            delete key[name]; // Deleting from attribute object
+          } else {
+            key = null;
+          }
         }
       }, this);
-      // Letting Backbone do its real set magic
-      returnValue = Backbone.Model.prototype.set.call(this, key, value, options);
-      // Unsetting means that all attributes get wiped, including our attribute
-      // relations, so we handle that.
-      if (options && options.unset) {
-        _.each(this.relations, function (constructor, name) {
-          if (name in attributes && this[name]) {
-            if (this[name] instanceof Backbone.Collection) {
-              // Reconnecting unset collections (since an unset collection attribute is just an empty collection)
-              defineRelatedAttribute(this, name, this[name]);
-            } else {
-              // Removing others unset relations
-              delete this[name];
-            }
-          }
-        }, this);
+      // Setting standard attributes the normal way
+      if (key) {
+        // Listening for change events from the attributes
+        this.on("change", function () { changeWasTriggered = true; }, "relational");
+        Backbone.Model.prototype.set.call(this, key, value, options);
+        this.off("change", null, "relational");
       }
-      return returnValue;
+      // Triggering delayed events from the relations
+      delayedEvents = getDelayedEvents(this);
+      if (delayedEvents) {
+        for (var i = 0, ln = delayedEvents.length; i < ln; i++) {
+          this.trigger.apply(this, delayedEvents[i]);
+        }
+        // No change event from the standard attributes - let's trigger one ourselves
+        if (!changeWasTriggered) {
+          this.trigger("change", [this]);
+        }
+      }
+      // Cleaning up
+      clearSettingData(this);
+      return this;
     }
   });
-
+  
   /**
-  * Connects a model attribute to a related model or collection
-  * @param model The model to add the connection to
-  * @param name The name of attribute
-  * @param object The backbone object to connect
+  * Returns kinship data for a model
+  * @param model A Backbone-kinship model
+  * @param key The key where the data is stored
+  * @return Stored data
   */
-  function defineRelatedAttribute(model, name, object) {
-    Object.defineProperty(model.attributes, name, {
-      configurable: true,
-      enumerable: true,
-      get: function () {
-        return object.toJSON();
-      },
-      set: function (value) {
-        var options = object._setOptions;
-        var method = options && options.reset && object.reset ? "reset" : "set";
-        delete object._setOptions;
-        return object[method](value, options);
-      }
-    });
+  function getSettingData(model, key) {
+    return settingData[model.cid] ? settingData[model.cid][key] : null;
+  }
+  
+  /**
+  * Stores kinship data for a model
+  * @param model A Backbone-kinship model
+  * @param key The key to store data at
+  * @param value The data to store
+  */
+  function setSettingData(model, key, value) {
+    if (!settingData[model.cid]) {
+      settingData[model.cid] = {};
+    }
+    settingData[model.cid][key] = value;
+  }
+  
+  /**
+  * Clears kinship data
+  * @param model A Backbone-kinship model
+  */
+  function clearSettingData(model) {
+    delete settingData[model.cid];
   }
 
   /**
-  * Delegates all events from one entity to another, on the format
-  * eventName:fromName.
-  * @param from The entity that emits the event
-  * @param to The entity that should receive the event
-  * @param fromName Display name to use for showing where this event originated
+  * Returns all attributes for a model
+  * Relational attributes will be JSONified
+  * @param model A Backbone-kinship model
+  * @return Model attributes
   */
-  function delegateEvents(from, to, fromName) {
-    from.bind("all", function () {
+  function getAttributes(model) {
+    var attributes = model._attributes;
+    // Adding expanded json data from all relations
+    _.each(model.relations, function(constructor, name) {
+      if (model[name]) {
+        attributes[name] = model[name].toJSON();
+      }
+    });
+    return attributes;
+  }
+  
+  /**
+  * Sets attributes to a model
+  * @param model A Backbone-kinship model
+  * @param value The value to set
+  */
+  function setAttributes(model, value) {
+    model._attributes = value;
+  }
+  
+  /**
+  * Adds a delayed event to a model
+  * @param model A Backbone-kinship model
+  * @param args Event arguments
+  */
+  function addDelayedEvent(model, args) {
+    var delayedEvents = getSettingData(model, "delayedEvents") || {};
+    delayedEvents[args[0]] = args; // Storing them this way to avoid duplicates
+    setSettingData(model, "delayedEvents", delayedEvents);
+  }
+  
+  /**
+  * Returns all delayed events for a model
+  * @param model A Backbone-kinship model
+  * @return An array of event arguments
+  */
+  function getDelayedEvents(model) {
+    return _.values(getSettingData(model, "delayedEvents") || {});
+  }
+  
+  /**
+  * Either returns or sets whether a model is setting data or not
+  * @param model A Backbone-kinshop model
+  * @param value If the model is setting or not (optional)
+  * @return True or false
+  */
+  function isSetting(model, value) {
+    if (typeof value !== "undefined") {
+      setSettingData(model, "isSetting", value);
+    }
+    return !!getSettingData(model, "isSetting");
+  }
+  
+  /*
+  * Delegates all events from one entity to another, on the format
+  * eventName:fromName. A "change" event will also be triggered for "add", "remove",
+  * "change" and "reset" events.
+  * @param relation The entity that emits the event
+  * @param model The entity that should receive the event
+  * @param relationName Display name to use to show where this event originated
+  */
+  function delegateEvents(relation, model, relationName) {
+    relation.bind("all", function () {
       var args = _.toArray(arguments); // Cloning
       var eventName = args[0];
-      args[0] = eventName + ":" + fromName;
-      to.trigger.apply(to, args);
+      var colonIndex = eventName.indexOf(":");
+      var eventType = colonIndex >= 0 ? eventName.substring(0, colonIndex) : eventName;
+      args[0] = eventName + ":" + relationName;
+      // Triggering events (change events are handled below)
+      if (eventType !== "change") {
+        model.trigger.apply(model, args);
+      }
+      // Triggering change events on the model
+      if (eventType === "change" || eventType === "update" || eventType === "reset") {
+        args[0] = "change:" + relationName;
+        args[1] = model; // Change events are triggered on model
+        if (isSetting(model)) {
+          // Delaying change events until _all_ model changes have been made
+          addDelayedEvent(model, args);
+        } else {
+          // We should be done - triggering right away
+          model.trigger.apply(model, args);
+          // Since we're not relying on the model to handle this we have to trigger our own change event
+          model.trigger("change", [model]);
+        }
+      }
     });
   }
 }));

--- a/backbone-kinship.js
+++ b/backbone-kinship.js
@@ -111,7 +111,7 @@
   * @param fromName Display name to use for showing where this event originated
   */
   function delegateEvents(from, to, fromName) {
-    from.bind("all", function() {
+    from.bind("all", function () {
       var args = _.toArray(arguments); // Cloning
       var eventName = args[0];
       args[0] = eventName + ":" + fromName;


### PR DESCRIPTION
Here's what expected:
1. Every event is triggered on its model/collection as normal.
2. Every event on a relation is also triggered on its parent as <eventName>:<relation>.
3. Change events are triggered when all setting is completed.
4. There should only be (at most) one single `change` event on a relational model.

This is meant to mimic how events on a standard Backbone model are triggered.

Fixes https://github.com/Oktavilla/backbone-kinship/issues/8
Fixes https://github.com/Oktavilla/backbone-kinship/issues/7 (as an
automatic side-effect, doing it otherwise would be complicated)
